### PR TITLE
가게목록 조회시 평점의 평균도 같이조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,27 @@ configurations {
     }
 }
 
+// QueryDSL 설정 추가
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file("$buildDir/generated/querydsl")
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs += "$buildDir/generated/querydsl"
+        }
+    }
+}
+
+tasks.register("cleanQuerydsl", Delete) {
+    delete file("$buildDir/generated/querydsl")
+}
+
+tasks.named("compileJava") {
+    dependsOn tasks.named("cleanQuerydsl")
+}
+
 repositories {
     mavenCentral()
 }

--- a/src/main/java/com/ana29/deliverymanagement/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/ana29/deliverymanagement/restaurant/controller/RestaurantController.java
@@ -4,11 +4,13 @@ import com.ana29.deliverymanagement.global.dto.ResponseDto;
 import com.ana29.deliverymanagement.order.dto.OrderHistoryResponseDto;
 import com.ana29.deliverymanagement.restaurant.dto.RestaurantRequestDto;
 import com.ana29.deliverymanagement.restaurant.dto.RestaurantResponseDto;
+import com.ana29.deliverymanagement.restaurant.dto.RestaurantWithRatingDto;
 import com.ana29.deliverymanagement.security.UserDetailsImpl;
 import com.ana29.deliverymanagement.restaurant.service.RestaurantService;
 import com.ana29.deliverymanagement.user.constant.user.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -50,17 +53,6 @@ public class RestaurantController {
                 .body(new ResponseDto<>(HttpStatus.OK, response));
     };
 
-    //가게 조회 메소드 (전체)
-    @GetMapping
-    public ResponseEntity<ResponseDto<Page<RestaurantResponseDto>>> getAllRestaurant(Pageable pageable){
-
-        Page<RestaurantResponseDto> response =
-                restaurantService.getAllRestaurant(pageable);
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new ResponseDto<>(HttpStatus.OK, response));
-    }
-
     //가게 삭제메소드(관리자,가게사장)
 
     //사용자의 권한확인 메소드
@@ -70,5 +62,15 @@ public class RestaurantController {
             throw new AccessDeniedException("관리자 접근이 필요합니다.");
         }
     };
+
+    //가게 목록과 평점을 조회 및 페이징 처리
+    @GetMapping
+    public ResponseDto<Page<RestaurantWithRatingDto>> getRestaurantsWithAverageRating(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        // 서비스 메서드 호출하여 가게 목록과 평균 평점 조회
+        return restaurantService.getRestaurantsWithAverageRating(page, size);
+    }
 
 }

--- a/src/main/java/com/ana29/deliverymanagement/restaurant/dto/RestaurantWithRatingDto.java
+++ b/src/main/java/com/ana29/deliverymanagement/restaurant/dto/RestaurantWithRatingDto.java
@@ -1,0 +1,38 @@
+package com.ana29.deliverymanagement.restaurant.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.util.UUID;
+
+@Getter
+@Setter
+public class RestaurantWithRatingDto {
+    private UUID id;
+    private String name;
+    private String ownerId;
+    private String operatingHours;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING) // JSON 직렬화 시 문자열로 변환
+    private String averageRating; // String 타입으로 변경
+
+    public RestaurantWithRatingDto(UUID id, String name, String ownerId, String operatingHours, Double averageRating) {
+        this.id = id;
+        this.name = name;
+        this.ownerId = ownerId;
+        this.operatingHours = operatingHours;
+        this.averageRating = formatRating(averageRating);
+    }
+
+    private String formatRating(Double rating) {
+        if (rating == null) {
+            return "0.0"; // null 방지
+        }
+        DecimalFormat df = new DecimalFormat("0.0"); // 소수점 한 자리까지만 표시
+        df.setRoundingMode(RoundingMode.HALF_UP); // 반올림 적용
+        return df.format(rating);
+    }
+}

--- a/src/main/java/com/ana29/deliverymanagement/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/ana29/deliverymanagement/restaurant/repository/RestaurantRepository.java
@@ -1,8 +1,12 @@
 package com.ana29.deliverymanagement.restaurant.repository;
 
+import com.ana29.deliverymanagement.restaurant.dto.RestaurantWithRatingDto;
 import com.ana29.deliverymanagement.restaurant.entity.Restaurant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
 
-public interface RestaurantRepository extends JpaRepository<Restaurant, UUID> {
+import java.util.UUID;
+public interface RestaurantRepository extends JpaRepository<Restaurant, UUID>, RestaurantRepositoryCustom {
 }

--- a/src/main/java/com/ana29/deliverymanagement/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/src/main/java/com/ana29/deliverymanagement/restaurant/repository/RestaurantRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.ana29.deliverymanagement.restaurant.repository;
+
+import com.ana29.deliverymanagement.restaurant.dto.RestaurantWithRatingDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RestaurantRepositoryCustom {
+    Page<RestaurantWithRatingDto> getRestaurantsWithAverageRating(Pageable pageable);
+}

--- a/src/main/java/com/ana29/deliverymanagement/restaurant/repository/RestaurantRepositoryCustomImpl.java
+++ b/src/main/java/com/ana29/deliverymanagement/restaurant/repository/RestaurantRepositoryCustomImpl.java
@@ -1,0 +1,56 @@
+package com.ana29.deliverymanagement.restaurant.repository;
+
+import com.ana29.deliverymanagement.restaurant.dto.RestaurantWithRatingDto;
+import com.ana29.deliverymanagement.restaurant.entity.QRestaurant;
+import com.ana29.deliverymanagement.review.entity.QReview;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+
+import java.util.List;
+
+public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public RestaurantRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<RestaurantWithRatingDto> getRestaurantsWithAverageRating(Pageable pageable) {
+        QRestaurant restaurant = QRestaurant.restaurant;
+        QReview review = QReview.review;
+
+        // 기본 쿼리 생성: 가게 목록
+        JPAQuery<RestaurantWithRatingDto> query = queryFactory
+                .select(
+                        Projections.constructor(RestaurantWithRatingDto.class,
+                                restaurant.id,
+                                restaurant.name,
+                                restaurant.ownerId,
+                                restaurant.operatingHours,
+                                // 리뷰의 평점 평균 계산
+                                review.rating.avg().as("averageRating")
+                        ))
+                .from(restaurant)
+                .leftJoin(review).on(review.restaurant.id.eq(restaurant.id)) // 리뷰와 가게 연결
+                .where(restaurant.isDeleted.isFalse()) // 삭제되지 않은 가게만 조회
+                .groupBy(restaurant.id);
+
+        // 페이징 처리
+        query.offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        // 결과 리스트 조회
+        List<RestaurantWithRatingDto> results = query.fetch();
+
+        // 페이징 처리된 결과 반환
+        return new PageImpl<>(results, pageable, query.fetchCount());
+    }
+}

--- a/src/main/java/com/ana29/deliverymanagement/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/ana29/deliverymanagement/restaurant/service/RestaurantService.java
@@ -2,14 +2,17 @@ package com.ana29.deliverymanagement.restaurant.service;
 
 import com.ana29.deliverymanagement.area.entity.Area;
 import com.ana29.deliverymanagement.area.repository.AreaRepository;
+import com.ana29.deliverymanagement.global.dto.ResponseDto;
 import com.ana29.deliverymanagement.restaurant.dto.RestaurantRequestDto;
 import com.ana29.deliverymanagement.restaurant.dto.RestaurantResponseDto;
+import com.ana29.deliverymanagement.restaurant.dto.RestaurantWithRatingDto;
 import com.ana29.deliverymanagement.restaurant.entity.Category;
 import com.ana29.deliverymanagement.restaurant.entity.Restaurant;
 import com.ana29.deliverymanagement.restaurant.repository.CategoryRepository;
 import com.ana29.deliverymanagement.restaurant.repository.RestaurantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,7 +62,13 @@ public class RestaurantService {
         return RestaurantResponseDto.from(restaurant);
     }
 
-    public Page<RestaurantResponseDto> getAllRestaurant(Pageable pageable) {
-        return null;
+    public ResponseDto<Page<RestaurantWithRatingDto>> getRestaurantsWithAverageRating(int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size);
+
+        // QueryDSL을 이용해 데이터를 조회
+        Page<RestaurantWithRatingDto> restaurantWithRatingDtos = restaurantRepository.getRestaurantsWithAverageRating(pageable);
+
+        // ResponseDto로 감싸서 반환
+        return ResponseDto.success(restaurantWithRatingDtos);
     }
 }

--- a/src/main/java/com/ana29/deliverymanagement/review/entity/Review.java
+++ b/src/main/java/com/ana29/deliverymanagement/review/entity/Review.java
@@ -17,7 +17,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE) // 빌더를 통한 생성만 허용
 @Builder
-@Table(name = "p_reviews")
+@Table(name = "p_review")
 public class Review extends Timestamped {
 
 	@Id


### PR DESCRIPTION
## 💡 이슈
- resolve #87 

## 🤩 개요
가게목록 조회시 평점의 평균도 같이조회

## 🧑‍💻 작업 사항
QueryDSL을 활용해 가게목록 조회시 평점의  평균도 같이 조회한다. 평점은 소숫점 첫째자리까지 반올림하여 표현한다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
![화면 캡처 2025-02-19 171646](https://github.com/user-attachments/assets/7a3b71f8-0374-42b4-b588-33d8724cf147)


