### PR TITLE
feat(order): 필터링 옵션 - foodTypes 추가

### DIFF
--- a/src/main/java/com/ana29/deliverymanagement/order/controller/OrderController.java
+++ b/src/main/java/com/ana29/deliverymanagement/order/controller/OrderController.java
@@ -8,6 +8,8 @@ import com.ana29.deliverymanagement.order.dto.OrderSearchCondition;
 import com.ana29.deliverymanagement.order.service.OrderService;
 import com.ana29.deliverymanagement.security.UserDetailsImpl;
 import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -61,10 +63,11 @@ public class OrderController {
 	@GetMapping("/my")
 	public ResponseEntity<ResponseDto<Page<OrderHistoryResponseDto>>> getOrderHistory(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@RequestParam(required = false) List<String> foodTypes,
 		@ModelAttribute OrderSearchCondition condition, Pageable pageable) {
 
 		Page<OrderHistoryResponseDto> response =
-			orderService.getOrderHistory(condition, pageable, userDetails.getUsername());
+			orderService.getOrderHistory(condition, pageable, userDetails.getUsername(), foodTypes);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ResponseDto.success(HttpStatus.OK, response));
 	}

--- a/src/main/java/com/ana29/deliverymanagement/order/dto/OrderHistoryResponseDto.java
+++ b/src/main/java/com/ana29/deliverymanagement/order/dto/OrderHistoryResponseDto.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 public record OrderHistoryResponseDto(UUID orderId,
 									  UUID restaurantId,
 									  String restaurantName,
+									  String foodType,
 									  String menuName,
 									  OrderStatusEnum orderStatus,
 									  OrderTypeEnum orderType,

--- a/src/main/java/com/ana29/deliverymanagement/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/ana29/deliverymanagement/order/repository/OrderRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.ana29.deliverymanagement.order.repository;
 import com.ana29.deliverymanagement.order.dto.OrderHistoryResponseDto;
 import com.ana29.deliverymanagement.order.dto.OrderSearchCondition;
 import com.ana29.deliverymanagement.order.entity.Order;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -12,7 +13,8 @@ public interface OrderRepositoryCustom {
 
 	Page<OrderHistoryResponseDto> findOrderHistory(String userId,
 		OrderSearchCondition condition,
-		Pageable pageable);
+		Pageable pageable,
+		List<String> categories);
 
 	Page<OrderHistoryResponseDto> findRestaurantOrderHistory(UUID restaurantId,
 		OrderSearchCondition condition, Pageable pageable);

--- a/src/main/java/com/ana29/deliverymanagement/order/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/ana29/deliverymanagement/order/repository/OrderRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.ana29.deliverymanagement.order.repository;
 
+import static com.ana29.deliverymanagement.restaurant.entity.QCategory.category;
 import static com.ana29.deliverymanagement.restaurant.entity.QMenu.menu;
 import static com.ana29.deliverymanagement.restaurant.entity.QRestaurant.restaurant;
 
@@ -33,104 +34,6 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 	QOrder order = QOrder.order;
 
 	@Override
-	public Page<OrderHistoryResponseDto> findOrderHistory(String ownerId,
-		OrderSearchCondition condition, Pageable pageable) {
-
-		List<OrderHistoryResponseDto> content = queryFactory
-			.select(Projections.constructor(OrderHistoryResponseDto.class,
-				order.id,
-				restaurant.id,
-				restaurant.name,
-				menu.name,
-				order.orderStatus,
-				order.orderType,
-				order.createdAt,
-				order.updatedAt))
-			.from(order)
-			.join(order.menu, menu)
-			.join(menu.restaurant, restaurant)
-			.where(
-				order.user.Id.eq(ownerId),
-				order.isDeleted.isFalse(),
-				order.orderStatus.ne(OrderStatusEnum.PENDING),
-				keywordContains(condition.keyword()),
-				statusIn(condition.statuses()),
-				createdAtBetween(condition.startDate(), condition.endDate()))
-			.orderBy(getOrderSpecifier(condition))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		Long fetchedCount = queryFactory
-			.select(order.count())
-			.from(order)
-			.join(order.menu, menu)
-			.join(menu.restaurant, restaurant)
-			.where(
-				order.user.Id.eq(ownerId),
-				order.isDeleted.isFalse(),
-				order.orderStatus.ne(OrderStatusEnum.PENDING),
-				keywordContains(condition.keyword()),
-				statusIn(condition.statuses()),
-				createdAtBetween(condition.startDate(), condition.endDate())
-			)
-			.fetchOne();
-
-		long total = fetchedCount != null ? fetchedCount : 0;
-
-		return new PageImpl<>(content, pageable, total);
-	}
-
-	@Override
-	public Page<OrderHistoryResponseDto> findRestaurantOrderHistory(UUID restaurantId,
-		OrderSearchCondition condition, Pageable pageable) {
-
-		List<OrderHistoryResponseDto> content = queryFactory
-			.select(Projections.constructor(OrderHistoryResponseDto.class,
-				order.id,
-				restaurant.id,
-				restaurant.name,
-				menu.name,
-				order.orderStatus,
-				order.orderType,
-				order.createdAt,
-				order.updatedAt))
-			.from(order)
-			.join(order.menu, menu)
-			.join(menu.restaurant, restaurant)
-			.where(
-				restaurant.id.eq(restaurantId),
-				order.isDeleted.isFalse(),
-				order.orderStatus.ne(OrderStatusEnum.PENDING),
-				keywordContains(condition.keyword()),
-				statusIn(condition.statuses()),
-				createdAtBetween(condition.startDate(), condition.endDate()))
-			.orderBy(getOrderSpecifier(condition))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		Long fetchedCount = queryFactory
-			.select(order.count())
-			.from(order)
-			.join(order.menu, menu)
-			.join(menu.restaurant, restaurant)
-			.where(
-				restaurant.id.eq(restaurantId),
-				order.isDeleted.isFalse(),
-				order.orderStatus.ne(OrderStatusEnum.PENDING),
-				keywordContains(condition.keyword()),
-				statusIn(condition.statuses()),
-				createdAtBetween(condition.startDate(), condition.endDate())
-			)
-			.fetchOne();
-
-		long total = fetchedCount != null ? fetchedCount : 0;
-
-		return new PageImpl<>(content, pageable, total);
-	}
-
-	@Override
 	public Optional<Order> findOrderById(UUID orderId, String userId) {
 		QUser user = QUser.user;
 
@@ -148,6 +51,90 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 			.fetchOne();
 
 		return Optional.ofNullable(result);
+	}
+
+	@Override
+	public Page<OrderHistoryResponseDto> findOrderHistory(String ownerId,
+		OrderSearchCondition condition, Pageable pageable, List<String> foodTypes) {
+
+		BooleanExpression additionalCondition = order.user.Id.eq(ownerId);
+
+		if (foodTypes != null && !foodTypes.isEmpty()) {
+			additionalCondition = additionalCondition.and(category.foodType.in(foodTypes));
+		}
+
+		List<OrderHistoryResponseDto> content = getOrderHistoryResponseDtoList(
+			additionalCondition, condition, pageable);
+
+		Long fetchedCount = getOrderHistoryCount(additionalCondition, condition);
+
+		long total = fetchedCount != null ? fetchedCount : 0;
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	@Override
+	public Page<OrderHistoryResponseDto> findRestaurantOrderHistory(UUID restaurantId,
+		OrderSearchCondition condition, Pageable pageable) {
+
+		BooleanExpression additionalCondition = restaurant.id.eq(restaurantId);
+
+		List<OrderHistoryResponseDto> content =
+			getOrderHistoryResponseDtoList(additionalCondition, condition, pageable);
+
+		Long fetchedCount = getOrderHistoryCount(additionalCondition, condition);
+
+		long total = fetchedCount != null ? fetchedCount : 0;
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private List<OrderHistoryResponseDto> getOrderHistoryResponseDtoList(BooleanExpression additionalCondition,
+		OrderSearchCondition condition, Pageable pageable) {
+		return queryFactory
+			.select(Projections.constructor(OrderHistoryResponseDto.class,
+				order.id,
+				restaurant.id,
+				restaurant.name,
+				restaurant.category.foodType,
+				menu.name,
+				order.orderStatus,
+				order.orderType,
+				order.createdAt,
+				order.updatedAt))
+			.from(order)
+			.join(order.menu, menu)
+			.join(menu.restaurant, restaurant)
+			.join(restaurant.category, category)
+			.where(
+				additionalCondition,
+				order.isDeleted.isFalse(),
+				order.orderStatus.ne(OrderStatusEnum.PENDING),
+				keywordContains(condition.keyword()),
+				statusIn(condition.statuses()),
+				createdAtBetween(condition.startDate(), condition.endDate()))
+			.orderBy(getOrderSpecifier(condition))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+
+	private Long getOrderHistoryCount(BooleanExpression additionalCondition, OrderSearchCondition condition) {
+		return queryFactory
+			.select(order.count())
+			.from(order)
+			.join(order.menu, menu)
+			.join(menu.restaurant, restaurant)
+			.join(restaurant.category, category)
+			.where(
+				additionalCondition,
+				order.isDeleted.isFalse(),
+				order.orderStatus.ne(OrderStatusEnum.PENDING),
+				keywordContains(condition.keyword()),
+				statusIn(condition.statuses()),
+				createdAtBetween(condition.startDate(), condition.endDate())
+			)
+			.fetchOne();
 	}
 
 

--- a/src/main/java/com/ana29/deliverymanagement/order/service/OrderService.java
+++ b/src/main/java/com/ana29/deliverymanagement/order/service/OrderService.java
@@ -24,6 +24,7 @@ import com.ana29.deliverymanagement.user.entity.UserAddress;
 import com.ana29.deliverymanagement.user.exception.UserAddressNotFoundException;
 import com.ana29.deliverymanagement.user.repository.UserAddressRepository;
 import com.ana29.deliverymanagement.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -100,8 +101,8 @@ public class OrderService {
 
 	@Transactional(readOnly = true)
 	public Page<OrderHistoryResponseDto> getOrderHistory(OrderSearchCondition condition,
-		Pageable pageable, String userId) {
-		return orderRepository.findOrderHistory(userId, condition, pageable);
+		Pageable pageable, String userId, List<String> foodTypes) {
+		return orderRepository.findOrderHistory(userId, condition, pageable, foodTypes);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/test/java/com/ana29/deliverymanagement/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/ana29/deliverymanagement/order/controller/OrderControllerTest.java
@@ -160,13 +160,14 @@ class OrderControllerTest {
 		Page<OrderHistoryResponseDto> pageResult = OrderDtoStub.createOrderHistoryPage();
 
 		when(orderService.getOrderHistory(any(OrderSearchCondition.class), any(Pageable.class),
-			anyString()))
+			anyString(), anyList()))
 			.thenReturn(pageResult);
 
 		// When & Then
 		mockMvc.perform(
 				OrderDtoStub.applyDefaultSearchParams(
 						get("/api/orders/my"))
+					.param("foodTypes", "한식", "중식")
 					.header("Authorization", MOCK_JWT_TOKEN)
 					.with(SecurityMockMvcRequestPostProcessors.user(userDetails)))
 			.andExpect(status().isOk())
@@ -175,7 +176,8 @@ class OrderControllerTest {
 				preprocessResponse(prettyPrint()),
 				requestHeaders(
 					headerWithName("Authorization").description("JWT 토큰")),
-				getQueryParametersSnippet(),
+				getQueryParametersSnippet()
+					.and(parameterWithName("foodTypes").description("카테고리 필터 (쉼표로 구분)").optional()),
 				getMyOrderResponseSnippet()));
 	}
 
@@ -302,6 +304,8 @@ class OrderControllerTest {
 				.description("음식점 ID"),
 			fieldWithPath("data.content[].restaurantName").type(JsonFieldType.STRING)
 				.description("음식점 이름"),
+			fieldWithPath("data.content[].foodType").type(JsonFieldType.STRING)
+				.description("식당 카테고리"),
 			fieldWithPath("data.content[].menuName").type(JsonFieldType.STRING)
 				.description("메뉴 이름"),
 			fieldWithPath("data.content[].orderStatus").type(JsonFieldType.STRING)

--- a/src/test/java/com/ana29/deliverymanagement/order/controller/OrderDtoStub.java
+++ b/src/test/java/com/ana29/deliverymanagement/order/controller/OrderDtoStub.java
@@ -77,6 +77,7 @@ public class OrderDtoStub {
 			TEST_ORDER_ID,
 			TEST_RESTAURANT_ID,
 			"맛있는 치킨",
+			"한식",
 			"후라이드 치킨",
 			OrderStatusEnum.PENDING,
 			OrderTypeEnum.ONLINE,


### PR DESCRIPTION
## 💡 이슈
- resolve #132 

## 🤩 개요
PR의 개요를 적어주세요.

## 🧑‍💻 작업 사항

내 주문 조회 에서만 foodType 파라미터를 추가했습니다
내 가게의 주문 조회에서는 해당 필터링옵션이 무용하다고 생각했어요 ~~

<img width="1344" alt="스크린샷 2025-02-22 오후 10 32 58" src="https://github.com/user-attachments/assets/ae1d1e78-af51-43d3-afc6-5b5e14810333" />
<img width="781" alt="스크린샷 2025-02-22 오후 10 36 18" src="https://github.com/user-attachments/assets/cacb81d3-5b93-4fa2-89af-9b2d153e5fa6" />

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
